### PR TITLE
Map an SQL BIT to a Java Boolean instead of Integer

### DIFF
--- a/src/main/java/com/speedment/core/platform/component/impl/SqlTypeMapperComponentImpl.java
+++ b/src/main/java/com/speedment/core/platform/component/impl/SqlTypeMapperComponentImpl.java
@@ -46,7 +46,7 @@ public class SqlTypeMapperComponentImpl implements SqlTypeMapperComponent {
         put("LONGVARCHAR", String.class);
         put("NUMERIC", BigDecimal.class);
         put("DECIMAL", BigDecimal.class);
-        put("BIT", Integer.class); ///
+        put("BIT", Boolean.class);
         put("TINYINT", Byte.class);
         put("SMALLINT", Short.class);
         put("INTEGER", Integer.class);


### PR DESCRIPTION
In my experience, BIT's are usually considered true/false values.

I also noticed that the class maps "BOOLEAN" to java.util.Boolean. As far as I know, MySQL doesn't have a type called BOOLEAN. If you create a column using BOOLEAN as the type, I think it'll become BIT(1) or TINYINT(1). Not sure about PostgreSQL. :)