### PR TITLE
Add custom time and string mappings for #52

### DIFF
--- a/src/main/java/com/speedment/internal/core/config/mapper/string/StringToLocaleMapper.java
+++ b/src/main/java/com/speedment/internal/core/config/mapper/string/StringToLocaleMapper.java
@@ -1,0 +1,50 @@
+/**
+*
+* Copyright (c) 2006-2015, Speedment, Inc. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); You may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package com.speedment.internal.core.config.mapper.string;
+
+import java.util.Locale;
+
+import com.speedment.config.mapper.TypeMapper;
+
+/**
+*
+* @author Maria Sparenberg
+* @author Patrick Hobusch
+*/
+public class StringToLocaleMapper implements TypeMapper<String, Locale> {
+
+    @Override
+    public Class<Locale> getJavaType() {
+        return Locale.class;
+    }
+
+    @Override
+    public Class<String> getDatabaseType() {
+        return String.class;
+    }
+
+    @Override
+    public Locale toJavaType(String value) {
+       return value == null ? null : new Locale(value);
+    }
+
+    @Override
+    public String toDatabaseType(Locale value) {
+       return value == null ? null : value.getLanguage();
+    }
+
+}

--- a/src/main/java/com/speedment/internal/core/config/mapper/string/TrueFalseStringToBooleanMapper.java
+++ b/src/main/java/com/speedment/internal/core/config/mapper/string/TrueFalseStringToBooleanMapper.java
@@ -1,0 +1,48 @@
+/**
+*
+* Copyright (c) 2006-2015, Speedment, Inc. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); You may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package com.speedment.internal.core.config.mapper.string;
+
+import com.speedment.config.mapper.TypeMapper;
+
+/**
+ *
+ * @author Maria Sparenberg
+ * @author Patrick Hobusch
+ */
+public class TrueFalseStringToBooleanMapper implements TypeMapper<String, Boolean> {
+
+    @Override
+    public Class<Boolean> getJavaType() {
+        return Boolean.class;
+    }
+
+    @Override
+    public Class<String> getDatabaseType() {
+        return String.class;
+    }
+
+    @Override
+    public Boolean toJavaType(String value) {
+        return value == null ? null : Boolean.valueOf(value);
+    }
+
+    @Override
+    public String toDatabaseType(Boolean value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+}

--- a/src/main/java/com/speedment/internal/core/config/mapper/string/YesNoStringToBooleanMapper.java
+++ b/src/main/java/com/speedment/internal/core/config/mapper/string/YesNoStringToBooleanMapper.java
@@ -1,0 +1,48 @@
+/**
+*
+* Copyright (c) 2006-2015, Speedment, Inc. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); You may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package com.speedment.internal.core.config.mapper.string;
+
+import com.speedment.config.mapper.TypeMapper;
+
+/**
+ *
+ * @author Maria Sparenberg
+ * @author Patrick Hobusch
+ */
+public class YesNoStringToBooleanMapper implements TypeMapper<String, Boolean> {
+
+    @Override
+    public Class<Boolean> getJavaType() {
+        return Boolean.class;
+    }
+
+    @Override
+    public Class<String> getDatabaseType() {
+        return String.class;
+    }
+
+    @Override
+    public Boolean toJavaType(String value) {
+        return value == null ? null : value.equalsIgnoreCase("yes");
+    }
+
+    @Override
+    public String toDatabaseType(Boolean value) {
+        return value == null ? null : (value ? "yes" : "no");
+    }
+
+}

--- a/src/main/java/com/speedment/internal/core/config/mapper/time/DateToLongMapper.java
+++ b/src/main/java/com/speedment/internal/core/config/mapper/time/DateToLongMapper.java
@@ -1,0 +1,50 @@
+/**
+ *
+ * Copyright (c) 2006-2015, Speedment, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); You may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.speedment.internal.core.config.mapper.time;
+
+import java.sql.Date;
+
+import com.speedment.config.mapper.TypeMapper;
+
+
+/**
+ *
+ * @author Maria Sparenberg
+ * @author Patrick Hobusch
+ */
+public class DateToLongMapper implements TypeMapper<Date, Long> {
+
+    @Override
+    public Class<Long> getJavaType() {
+        return Long.class;
+    }
+
+    @Override
+    public Class<Date> getDatabaseType() {
+        return Date.class;
+    }
+
+    @Override
+    public Long toJavaType(Date value) {
+        return value == null ? null : value.getTime();
+    }
+
+    @Override
+    public Date toDatabaseType(Long value) {
+        return value == null ? null : new Date(value);
+    }
+}

--- a/src/main/java/com/speedment/internal/core/config/mapper/time/TimeToLongMapper.java
+++ b/src/main/java/com/speedment/internal/core/config/mapper/time/TimeToLongMapper.java
@@ -1,0 +1,49 @@
+/**
+ *
+ * Copyright (c) 2006-2015, Speedment, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); You may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.speedment.internal.core.config.mapper.time;
+
+import com.speedment.config.mapper.TypeMapper;
+
+import java.sql.Time;
+
+/**
+ *
+ * @author Maria Sparenberg
+ * @author Patrick Hobusch
+ */
+public class TimeToLongMapper implements TypeMapper<Time, Long> {
+
+    @Override
+    public Class<Long> getJavaType() {
+        return Long.class;
+    }
+
+    @Override
+    public Class<Time> getDatabaseType() {
+        return Time.class;
+    }
+
+    @Override
+    public Long toJavaType(Time value) {
+        return value == null ? null : value.getTime();
+    }
+
+    @Override
+    public Time toDatabaseType(Long value) {
+        return value == null ? null : new Time(value);
+    }
+}

--- a/src/main/java/com/speedment/internal/core/config/mapper/time/TimestampToLongMapper.java
+++ b/src/main/java/com/speedment/internal/core/config/mapper/time/TimestampToLongMapper.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.speedment.internal.core.config.dbms.timestamp;
+package com.speedment.internal.core.config.mapper.time;
 
 import com.speedment.config.mapper.TypeMapper;
 import java.sql.Timestamp;

--- a/src/main/java/com/speedment/internal/core/platform/component/impl/TypeMapperComponentImpl.java
+++ b/src/main/java/com/speedment/internal/core/platform/component/impl/TypeMapperComponentImpl.java
@@ -19,7 +19,6 @@ package com.speedment.internal.core.platform.component.impl;
 import com.speedment.Speedment;
 import com.speedment.component.TypeMapperComponent;
 import com.speedment.config.mapper.TypeMapper;
-import com.speedment.internal.core.config.dbms.timestamp.TimestampToLongMapper;
 import com.speedment.internal.core.config.mapper.identity.ArrayIdentityMapper;
 import com.speedment.internal.core.config.mapper.identity.BigDecimalIdentityMapper;
 import com.speedment.internal.core.config.mapper.identity.BlobIdentityMapper;
@@ -41,6 +40,13 @@ import com.speedment.internal.core.config.mapper.identity.StringIdentityMapper;
 import com.speedment.internal.core.config.mapper.identity.TimeIdentityMapper;
 import com.speedment.internal.core.config.mapper.identity.TimestampIdentityMapper;
 import com.speedment.internal.core.config.mapper.identity.URLIdentityMapper;
+import com.speedment.internal.core.config.mapper.string.StringToLocaleMapper;
+import com.speedment.internal.core.config.mapper.string.TrueFalseStringToBooleanMapper;
+import com.speedment.internal.core.config.mapper.string.YesNoStringToBooleanMapper;
+import com.speedment.internal.core.config.mapper.time.DateToLongMapper;
+import com.speedment.internal.core.config.mapper.time.TimeToLongMapper;
+import com.speedment.internal.core.config.mapper.time.TimestampToLongMapper;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -88,8 +94,15 @@ public final class TypeMapperComponentImpl extends Apache2AbstractComponent impl
         install(TimestampIdentityMapper::new);
         install(URLIdentityMapper::new);
         
-        // Special timestamp mappers
+        // Special time mappers
+        install(DateToLongMapper::new);
         install(TimestampToLongMapper::new);
+        install(TimeToLongMapper::new);
+        
+        // Special string mappers
+        install(StringToLocaleMapper::new);
+        install(TrueFalseStringToBooleanMapper::new);
+        install(YesNoStringToBooleanMapper::new);
     }
 
     @Override

--- a/src/test/java/com/speedment/internal/core/config/mapper/string/StringToLocaleMapperTest.java
+++ b/src/test/java/com/speedment/internal/core/config/mapper/string/StringToLocaleMapperTest.java
@@ -1,0 +1,50 @@
+/**
+ *
+ * Copyright (c) 2006-2015, Speedment, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); You may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.speedment.internal.core.config.mapper.string;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Maria Sparenberg
+ * @author Patrick Hobusch
+ */
+public class StringToLocaleMapperTest {
+
+    private StringToLocaleMapper mapper;
+
+    @Before
+    public void setUp() {
+        mapper = new StringToLocaleMapper();
+    }
+
+    @Test
+    public void testStringLocaleMapping() {
+        String string = "DE";
+
+        Locale javaType = mapper.toJavaType(string);
+        Assert.assertEquals("JavaType should have value 'de'", new Locale("de"), javaType);
+
+        String databaseType = mapper.toDatabaseType(javaType);
+        Assert.assertTrue("DatabaseType should have value 'de'", string.equalsIgnoreCase(databaseType));
+    }
+}

--- a/src/test/java/com/speedment/internal/core/config/mapper/string/TrueFalseStringToBooleanMapperTest.java
+++ b/src/test/java/com/speedment/internal/core/config/mapper/string/TrueFalseStringToBooleanMapperTest.java
@@ -1,0 +1,59 @@
+/**
+ *
+ * Copyright (c) 2006-2015, Speedment, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); You may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.speedment.internal.core.config.mapper.string;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Maria Sparenberg
+ * @author Patrick Hobusch
+ */
+public class TrueFalseStringToBooleanMapperTest {
+
+    private TrueFalseStringToBooleanMapper mapper;
+
+    @Before
+    public void setUp() {
+        mapper = new TrueFalseStringToBooleanMapper();
+    }
+
+    @Test
+    public void testStringTrueMapping() {
+        String string = "TRUE";
+
+        Boolean javaType = mapper.toJavaType(string);
+        Assert.assertEquals("JavaType should have value 'true'",  true, javaType);
+
+        String databaseType = mapper.toDatabaseType(javaType);
+        Assert.assertTrue("DatabaseType should have value 'true'", string.equalsIgnoreCase(databaseType));
+    }
+
+    @Test
+    public void testStringFalseMapping() {
+        String string = "FALSE";
+
+        Boolean javaType = mapper.toJavaType(string);
+        Assert.assertEquals("JavaType should have value 'false'",  false, javaType);
+
+        String databaseType = mapper.toDatabaseType(javaType);
+        Assert.assertTrue("DatabaseType should have value 'true'", string.equalsIgnoreCase(databaseType));
+    }
+}

--- a/src/test/java/com/speedment/internal/core/config/mapper/string/YesNoStringToBooleanMapperTest.java
+++ b/src/test/java/com/speedment/internal/core/config/mapper/string/YesNoStringToBooleanMapperTest.java
@@ -1,0 +1,59 @@
+/**
+ *
+ * Copyright (c) 2006-2015, Speedment, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); You may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.speedment.internal.core.config.mapper.string;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Maria Sparenberg
+ * @author Patrick Hobusch
+ */
+public class YesNoStringToBooleanMapperTest {
+
+    private YesNoStringToBooleanMapper mapper;
+
+    @Before
+    public void setUp() {
+        mapper = new YesNoStringToBooleanMapper();
+    }
+
+    @Test
+    public void testStringYesMapping() {
+        String string = "YES";
+
+        Boolean javaType = mapper.toJavaType(string);
+        Assert.assertEquals("JavaType should have value 'true'",  true, javaType);
+
+        String databaseType = mapper.toDatabaseType(javaType);
+        Assert.assertTrue("DatabaseType should have value 'yes'", string.equalsIgnoreCase(databaseType));
+    }
+
+    @Test
+    public void testStringNoMapping() {
+        String string = "NO";
+
+        Boolean javaType = mapper.toJavaType(string);
+        Assert.assertEquals("JavaType should have value 'false'",  false, javaType);
+
+        String databaseType = mapper.toDatabaseType(javaType);
+        Assert.assertTrue("DatabaseType should have value 'no'", string.equalsIgnoreCase(databaseType));
+    }
+}


### PR DESCRIPTION
Hi,

we started to implement some custom type mappers:
* DateToLongMapper, TimeToLongMapper (almost identical to TimestampToLongMapper)
* StringToLocaleMapper
* TrueFalseStringToBooleanMapper
* YesNoStringToBooleanMapper

We think the old package of TimestampToLongMapper was too specific and at the wrong place, so that we placed all the time mappers in `com.speedment.internal.core.config.mapper.time`.

Analogously, we placed the other three string mappers in `com.speedment.internal.core.config.mapper.string`.

Furthermore we added simple unit tests for the string mappers. We think the Date-, Time- and Timestamp-Implementation have too much own logic to write unit tests for the mappers.