### PR TITLE
Make sure base package name is in lower case.

### DIFF
--- a/src/main/java/com/speedment/internal/core/code/JavaClassTranslator.java
+++ b/src/main/java/com/speedment/internal/core/code/JavaClassTranslator.java
@@ -206,9 +206,9 @@ public interface JavaClassTranslator<T extends Node> extends Translator<T, File>
     default String basePackageName() {
         final String packName = project().getPackageName().toLowerCase() + ".";
         if (getNode() instanceof Project) {
-            return packName + project().getName();
+            return packName + project().getName().toLowerCase();
         } else {
-            return packName + getNode().getRelativeName(Project.class, JavaLanguage::javaPacketName);
+            return packName + getNode().getRelativeName(Project.class, JavaLanguage::javaPacketName).toLowerCase();
         }
     }
 


### PR DESCRIPTION
To avoid class names such as:
```
com.companyname.applicationame.ApplicationName.ApplicationNameApplication.java
```