### PR TITLE
Removed redundant suppress.

### DIFF
--- a/src/main/java/com/speedment/internal/core/code/entity/EntityImplTranslator.java
+++ b/src/main/java/com/speedment/internal/core/code/entity/EntityImplTranslator.java
@@ -253,7 +253,6 @@ public final class EntityImplTranslator extends EntityAndManagerTranslator<Class
                 .add(Field.of(thatName, OBJECT))
                 .add("if (this == that) { return true; }")
                 .add("if (!(" + thatName + " instanceof " + ENTITY.getName() + ")) { return false; }")
-                .add("@SuppressWarnings(\"unchecked\")")
                 .add("final " + ENTITY.getName() + " " + thatCastedName + " = (" + ENTITY.getName() + ")" + thatName + ";");
 
         columns().forEachOrdered(c -> {


### PR DESCRIPTION
I was getting a warning about unnecessary suppress in Eclipse.
There are only warnings about unchecked cast when generics are involved, and (correct me if I'm wrong) entities will never be generic.