### PR TITLE
Fixes #387

### DIFF
--- a/build-parent/maven-plugin/pom.xml
+++ b/build-parent/maven-plugin/pom.xml
@@ -102,6 +102,31 @@
             <version>${mariadb-jdbc-version}</version>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.4</version>
+            <scope>test</scope>
+        </dependency>
         
     </dependencies>
 

--- a/build-parent/maven-plugin/src/main/java/com/speedment/maven/abstractmojo/AbstractReloadMojo.java
+++ b/build-parent/maven-plugin/src/main/java/com/speedment/maven/abstractmojo/AbstractReloadMojo.java
@@ -62,6 +62,7 @@ public abstract class AbstractReloadMojo extends AbstractSpeedmentMojo {
         final ConfigFileHelper helper = speedment.getOrThrow(ConfigFileHelper.class);
         
         try {
+            helper.setCurrentlyOpenFile(configLocation());
             helper.loadFromDatabaseAndSaveToFile();
         } catch (final Exception ex) {
             final String err = "An error occured while reloading.";

--- a/build-parent/maven-plugin/src/test/java/com/speedment/maven/abstractmojo/AbstractReloadMojoTest.java
+++ b/build-parent/maven-plugin/src/test/java/com/speedment/maven/abstractmojo/AbstractReloadMojoTest.java
@@ -1,0 +1,51 @@
+package com.speedment.maven.abstractmojo;
+
+import com.speedment.runtime.core.Speedment;
+import com.speedment.tool.core.internal.util.ConfigFileHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// Since ConfigFileHelper is final we need to use Powermock so it is possible to actually mock it.
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ConfigFileHelper.class})
+public class AbstractReloadMojoTest {
+
+    private AbstractReloadMojo mojo;
+
+    @Mock
+    private File mockedConfigLocation;
+    @Mock
+    private Speedment mockedSpeedment;
+    @Mock
+    private ConfigFileHelper mockedConfigFileHelper;
+
+    @Before
+    public void setup() {
+        mojo = new AbstractReloadMojoTestImpl();
+    }
+
+    @Test
+    public void execute() throws Exception {
+        // Given
+        when(mockedSpeedment.getOrThrow(ConfigFileHelper.class)).thenReturn(mockedConfigFileHelper);
+        Whitebox.setInternalState(mojo, "configFile", mockedConfigLocation);
+
+        // When
+        mojo.execute(mockedSpeedment);
+
+        // Then
+        verify(mockedConfigFileHelper).setCurrentlyOpenFile(mockedConfigLocation);
+        verify(mockedConfigFileHelper).loadFromDatabaseAndSaveToFile();
+    }
+
+}

--- a/build-parent/maven-plugin/src/test/java/com/speedment/maven/abstractmojo/AbstractReloadMojoTestImpl.java
+++ b/build-parent/maven-plugin/src/test/java/com/speedment/maven/abstractmojo/AbstractReloadMojoTestImpl.java
@@ -1,0 +1,20 @@
+package com.speedment.maven.abstractmojo;
+
+import com.speedment.runtime.core.Speedment;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+/**
+ * test implementaiton of AbstractReloadMojo
+ */
+public class AbstractReloadMojoTestImpl extends AbstractReloadMojo {
+
+    @Override
+    protected String launchMessage() {
+        return "test implementaiton of AbstractReloadMojo";
+    }
+
+    public void execute(Speedment speedment) throws MojoFailureException, MojoExecutionException {
+        super.execute(speedment);
+    }
+}


### PR DESCRIPTION
Fixes a bug with the maven reload goal. The bug meant that the configFile configuration property was ignored by the relad goal. This has been fixed.

This can be tested by setting up a multi module project where the Speedment reload takes place in a sub-module. Before the fix, any generated JSON file would always be in the root project under src/main/json/speedment.json.

Through this fix, it is possible to create the json file in any location, this is done by setting the configFile configuration proerty, for example:
<configFile>${project.basedir}/src/main/json/speedment.json</configFile>
This puts it in the src folder relative to the module.
